### PR TITLE
Adding interactive list mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 bin/
-dist/

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,59 +1,81 @@
 ---
 kind: pipeline
 name: default
-# Build
+
+platform:
+  os: linux
+  arch: amd64
+
 steps:
-- name: build
+- name: build-binaries
   image: golang:1.12
-  environment:
-    VERSION: DEV
-    REVISION: ${DRONE_COMMIT}
   commands:
-    - make bootstrap
-    - make build build-dev
+  - make build build-dev
+  environment:
+    REVISION: "${DRONE_COMMIT}"
+    VERSION: DEV
   when:
     event:
-      - push
+    - push
+
+- name: build-docker
+  image: plugins/docker
+  settings:
+    build_args:
+    - VER=DEBUG
+    dry_run: true
+    repo: danmx/sigil
+    tags:
+    - debug
+    target: debug
+  when:
+    event:
+    - push
+
 - name: build-release
   image: golang:1.12
-  environment:
-    VERSION: ${DRONE_TAG}
-    REVISION: ${DRONE_COMMIT}
   commands:
-    - make bootstrap
-    - make build
+  - make build
+  environment:
+    REVISION: "${DRONE_COMMIT}"
+    VERSION: "${DRONE_TAG}"
   when:
     event:
-      - tag
-# Docker Hub
+    - tag
+
 - name: docker-release
   image: plugins/docker
   settings:
-    repo: danmx/sigil
-    target: prod
     auto_tag: true
-    username:
-      from_secret: docker_username
+    build_args:
+    - "VER=\"${DRONE_TAG}\""
     password:
       from_secret: docker_password
+    repo: danmx/sigil
+    target: prod
+    username:
+      from_secret: docker_username
   when:
-    event: tag
-# GitHub Release
+    event:
+    - tag
+
 - name: github-release
   image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
-    files:
-      - dist/*
     checksum:
-      - sha1
-      - sha256
-      - sha512
+    - sha1
+    - sha256
+    - sha512
+    files:
+    - "bin/release/*"
   when:
-    event: tag
+    event:
+    - tag
+
 ---
 kind: signature
-hmac: 37f96f5abde3a97fe6fafd29ae486cf5a1c1587089a7f9640d1119fc83ba782b
+hmac: c5d1fc4ed9927d6d609372c169a0865745eb335137991718bd07ff3f20763d66
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,7 @@ steps:
   settings:
     build_args:
     - VER=DEBUG
+    - "REV=\"${DRONE_COMMIT}\""
     dry_run: true
     repo: danmx/sigil
     tags:
@@ -49,6 +50,7 @@ steps:
     auto_tag: true
     build_args:
     - "VER=\"${DRONE_TAG}\""
+    - "REV=\"${DRONE_COMMIT}\""
     password:
       from_secret: docker_password
     repo: danmx/sigil
@@ -76,6 +78,6 @@ steps:
 
 ---
 kind: signature
-hmac: c5d1fc4ed9927d6d609372c169a0865745eb335137991718bd07ff3f20763d66
+hmac: 901f0710cced99e0a6773ba2ad29e6bfaa825c20cb418a4b01262004c2212daf
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.12 as build
 
 ARG VER
+ARG REV
 ENV VERSION=${VER}
+ENV REVISION=${REV}
 
 ENV URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb"
 # session-manager-plugin.deb sha26 hash
@@ -10,7 +12,7 @@ ENV SHA256_HASH=f343169dd1dab6ba418b200ac16ddd3c36494095bd244c5c817a1a185467df9e
 WORKDIR /go/src/app
 COPY . .
 
-RUN make build-linux build-linux-dev
+RUN make bootstrap build-linux build-linux-dev
 RUN curl "${URL}" \
     -o "session-manager-plugin.deb" \
     && [ "${SHA256_HASH}" = "$(shasum -a 256 session-manager-plugin.deb | awk '{print $1}')" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN dpkg -i session-manager-plugin.deb
 
 FROM gcr.io/distroless/base:debug as debug
 COPY --from=build /usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
-COPY --from=build /go/src/app/bin/sigil-linux /sigil
+COPY --from=build /go/src/app/bin/dev/sigil-linux /sigil
 ENTRYPOINT [ "/sigil" ]
 CMD [ "--help" ]
 
 FROM gcr.io/distroless/base as prod
 COPY --from=build /usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
-COPY --from=build /go/src/app/dist/sigil-linux /sigil
+COPY --from=build /go/src/app/bin/release/sigil-linux /sigil
 ENTRYPOINT [ "/sigil" ]
 CMD [ "--help" ]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-mac:
 		-X main.Revision=$(REVISION)" -o bin/release/$(NAME)-darwin cmd/$(NAME)/main.go
 
 build-docker:
-	@docker build --build-arg VER=$(VERSION) -t $(NAME):$(VERSION) .
+	@docker build --build-arg VER=$(VERSION) --build-arg REV=$(REVISION) -t $(NAME):$(VERSION) .
 
 build-windows-dev: export GOARCH=amd64
 build-windows-dev:

--- a/Makefile
+++ b/Makefile
@@ -23,21 +23,21 @@ build-windows: export GOARCH=amd64
 build-windows:
 	@GOOS=windows go build -mod=vendor -v \
 		--ldflags="-w -X main.AppName=$(NAME) -X main.Version=$(VERSION) \
-		-X main.Revision=$(REVISION)" -o dist/$(NAME)-windows cmd/$(NAME)/main.go
+		-X main.Revision=$(REVISION)" -o bin/release/$(NAME)-windows cmd/$(NAME)/main.go
 
 build-linux: export GOARCH=amd64
 build-linux: export CGO_ENABLED=0
 build-linux:
 	@GOOS=linux go build -mod=vendor -v \
 		--ldflags="-w -X main.AppName=$(NAME) -X main.Version=$(VERSION) \
-		-X main.Revision=$(REVISION)" -o dist/$(NAME)-linux cmd/$(NAME)/main.go
+		-X main.Revision=$(REVISION)" -o bin/release/$(NAME)-linux cmd/$(NAME)/main.go
 
 build-mac: export GOARCH=amd64
 build-mac: export CGO_ENABLED=0
 build-mac:
 	@GOOS=darwin go build -mod=vendor -v \
 		--ldflags="-w -X main.AppName=$(NAME) -X main.Version=$(VERSION) \
-		-X main.Revision=$(REVISION)" -o dist/$(NAME)-darwin cmd/$(NAME)/main.go
+		-X main.Revision=$(REVISION)" -o bin/release/$(NAME)-darwin cmd/$(NAME)/main.go
 
 build-docker:
 	@docker build --build-arg VER=$(VERSION) -t $(NAME):$(VERSION) .
@@ -47,7 +47,7 @@ build-windows-dev:
 	@GOOS=windows go build -mod=vendor -v \
 		--ldflags="-w -X main.LogLevel=debug -X main.AppName=$(NAME) \
 		-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
-		-o bin/$(NAME)-windows cmd/$(NAME)/main.go
+		-o bin/dev/$(NAME)-windows cmd/$(NAME)/main.go
 
 build-linux-dev: export GOARCH=amd64
 build-linux-dev: export CGO_ENABLED=0
@@ -55,7 +55,7 @@ build-linux-dev:
 	@GOOS=linux go build -mod=vendor -v \
 		--ldflags="-w -X main.LogLevel=debug -X main.AppName=$(NAME) \
 		-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
-		-o bin/$(NAME)-linux cmd/$(NAME)/main.go
+		-o bin/dev/$(NAME)-linux cmd/$(NAME)/main.go
 
 build-mac-dev: export GOARCH=amd64
 build-mac-dev: export CGO_ENABLED=0
@@ -63,7 +63,7 @@ build-mac-dev:
 	@GOOS=darwin go build -mod=vendor -v \
 		--ldflags="-w -X main.LogLevel=debug -X main.AppName=$(NAME) \
 		-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
-		-o bin/$(NAME)-darwin cmd/$(NAME)/main.go
+		-o bin/dev/$(NAME)-darwin cmd/$(NAME)/main.go
 
 .PHONY: get-version
 get-version:
@@ -82,4 +82,4 @@ test:
 
 .PHONY: drone-sign
 drone-sign:
-	@drone sign $(REPO) --save
+	@drone fmt --save .drone.yml && drone sign $(REPO) --save

--- a/cmd/sigil/main.go
+++ b/cmd/sigil/main.go
@@ -68,6 +68,7 @@ var (
 	targetType    string
 	outputFormat  string
 	configProfile string
+	startSession  bool
 	cfgFile       = "config.yaml"
 	workDirName   = "." + AppName
 	pluginName    = "session-manager-plugin"
@@ -157,6 +158,11 @@ func main() {
 			Usage: "specify tags to filter out results, e.g.: `key1=value1,key2=value2`",
 			Value: &stringMapStringType{},
 		},
+		cli.BoolFlag{
+			Name:        "interactive, i",
+			Usage:       "allows to pick an instance and start the session",
+			Destination: &startSession,
+		},
 	}
 
 	sessionFlags := []cli.Flag{
@@ -191,16 +197,12 @@ func main() {
 					OutputFormat: &outputFormat,
 					AWSRegion:    &awsRegion,
 					TagFilter:    &tagFilter.Map,
+					StartSession: &startSession,
 				}
-				output, err := list.Start(input)
+				err := list.Start(input)
 				if err != nil {
 					return err
 				}
-				stringOuput, err := output.String()
-				if err != nil {
-					return err
-				}
-				fmt.Print(stringOuput)
 				return nil
 			},
 			Before: func(c *cli.Context) error {


### PR DESCRIPTION
Addressing https://github.com/danmx/sigil/issues/6

This PR introduces an interactive mode for `list` command. You can choose an instance you want to connect to.

Example:
```console
$ sigil-darwin ls -i

Index  Name             Instance ID          IP Address    Private DNS Name
1      Node1            i-xxxxxxxxxxxxxxxx1  192.168.0.5   ip-192-168-0-5.eu-west-1.compute.internal
2      Node2            i-xxxxxxxxxxxxxxxx2  192.168.0.6   ip-192-0-145-6.eu-west-1.compute.internal
3      Node3            i-xxxxxxxxxxxxxxxx3  192.168.0.57  ip-192-0-147-7.eu-west-1.compute.internal
Choose an instance to connect to [1 - 3]: 
```

![](https://media.giphy.com/media/3oipPTHYlTpCw8oBBy/giphy.gif)