### PR TITLE
pins session manager so updates won't break the shasum validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG REV
 ENV VERSION=${VER}
 ENV REVISION=${REV}
 
-ENV URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb"
+ENV URL="https://s3.amazonaws.com/session-manager-downloads/plugin/1.1.54.0/ubuntu_64bit/session-manager-plugin.deb"
 
 WORKDIR /go/src/app
 COPY . .

--- a/session-manager-plugin.sha256
+++ b/session-manager-plugin.sha256
@@ -1,1 +1,1 @@
-1cb46dc70aef765ab8ba5b07b4ff3fe21aea524519af95feb16d5a72bfdb6421  session-manager-plugin.deb
+342602b05552268966bcac2ec7698447e1202eb8e3d2943066dd9954697604ef  session-manager-plugin.deb


### PR DESCRIPTION
Looks like the [most recent build](https://cloud.drone.io/danmx/sigil/204/1/5) is broken.

The session manager plugin has been updated since the last shasum was committed. This change will set the version in the download URL so an update from AWS to the session manager plugin will not break future builds.
