### PR TITLE
use IdentitiesOnly option in ssh_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Add an entry to your `ssh_config`:
 Host i-* mi-*
     User ec2-user
     IdentityFile ~/.sigil/temp_key
+    IdentitiesOnly yes
     ProxyCommand sh -c 'sigil ssh --target %h --port %p --pub-key "${HOME}"/.sigil/temp_key.pub --gen-key-pair'
 Host *.compute.internal
     User ec2-user
     IdentityFile ~/.sigil/temp_key
+    IdentitiesOnly yes
     ProxyCommand sh -c 'sigil ssh --type private-dns --target %h --port %p --pub-key "${HOME}"/.sigil/temp_key.pub --gen-key-pair'
 ```
 


### PR DESCRIPTION
to prevent "Too many authentication failures" due to tries of other keys.