### PR TITLE
fix(doc): adding missing flag in ssh_config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Add an entry to your `ssh_config`:
 Host i-* mi-*
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r
+    ProxyCommand sigil ssh --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
 Host *.compute.internal
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --type private-dns --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r
+    ProxyCommand sigil ssh --type private-dns --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
 ```
 
 and run:


### PR DESCRIPTION
Signed-off-by: danmx <daniel@iziourov.info>