### PR TITLE
Rolling back removal of name-tag session and ssh target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - **deps:** update l.gcr.io/google/bazel docker tag to v3.3.0
 - **pre-commit:** add go mod tidy to update_deps
 
+### Update
+- **go:** version 1.14.4
+
 
 <a name="0.5.2"></a>
 ## [0.5.2] - 2020-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - **deps:** update l.gcr.io/google/bazel docker tag to v3.3.0
 - **pre-commit:** add go mod tidy to update_deps
 
+### Rollback
+- name-tag target type change
+
 ### Update
 - **go:** version 1.14.4
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.14.3",
+    go_version = "1.14.4",
 )
 
 # gazelle

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -60,5 +60,5 @@ func init() {
 	rootCmd.AddCommand(sessionCmd)
 
 	sessionCmd.Flags().String("target", "", "specify the target depending on the type")
-	sessionCmd.Flags().String("type", aws.TargetTypeInstanceID, fmt.Sprintf("specify target type: %s/%s/%s", aws.TargetTypeInstanceID, aws.TargetTypePrivateDNS, aws.TargetTypeName))
+	sessionCmd.Flags().String("type", aws.TargetTypeInstanceID, fmt.Sprintf("specify target type: %s/%s/%s/%s (deprecated)", aws.TargetTypeInstanceID, aws.TargetTypePrivateDNS, aws.TargetTypeName, aws.DeprecatedTargetTypeName))
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -102,7 +102,7 @@ func init() {
 	rootCmd.AddCommand(sshCmd)
 
 	sshCmd.Flags().String("target", "", "specify the target depending on the type")
-	sshCmd.Flags().String("type", aws.TargetTypeInstanceID, fmt.Sprintf("specify target type: %s/%s/%s", aws.TargetTypeInstanceID, aws.TargetTypePrivateDNS, aws.TargetTypeName))
+	sshCmd.Flags().String("type", aws.TargetTypeInstanceID, fmt.Sprintf("specify target type: %s/%s/%s/%s (deprecated)", aws.TargetTypeInstanceID, aws.TargetTypePrivateDNS, aws.TargetTypeName, aws.DeprecatedTargetTypeName))
 	sshCmd.Flags().Bool("gen-key-pair", false, fmt.Sprintf("generate a temporary key pair that will be send and used. By default use %s as an identity file", path.Join(workDir, tempKeyName)))
 	sshCmd.Flags().String("gen-key-dir", workDir, "the directory where temporary keys will be generated")
 	sshCmd.Flags().String("os-user", "ec2-user", "specify an instance OS user which will be using sent public key")

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -90,6 +90,8 @@ const (
 	TargetTypePrivateDNS = "private-dns"
 	// TargetTypeName points to a name type
 	TargetTypeName = "name"
+	// DeprecatedTargetTypeName points to a name type
+	DeprecatedTargetTypeName = "name-tag"
 )
 
 // NewWithConfig will generate an AWS Provider with given configuration
@@ -174,6 +176,17 @@ func (p *Provider) getInstance(targetType, target string) (*ec2.Instance, error)
 			},
 		}
 	case TargetTypeName:
+		filters = []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []*string{&target},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []*string{aws.String("running")},
+			},
+		}
+	case DeprecatedTargetTypeName:
 		filters = []*ec2.Filter{
 			{
 				Name:   aws.String("tag:Name"),

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -64,4 +64,15 @@ func TestStart(t *testing.T) {
 		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
 	)
 	assert.NoError(t, input.start(m))
+	// Deprecated Name
+	targetType = aws.DeprecatedTargetTypeName
+	gomock.InOrder(
+		m.EXPECT().NewWithConfig(gomock.Eq(&aws.Config{
+			Region:   *input.Region,
+			Profile:  *input.Profile,
+			MFAToken: *input.MFAToken,
+		})).Return(nil),
+		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
+	)
+	assert.NoError(t, input.start(m))
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestStart verifies start ssh method
 func TestStart(t *testing.T) {
+	// Instance
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	m := NewMockCloudSSH(ctrl) // skipcq: SCC-compile
@@ -30,6 +31,101 @@ func TestStart(t *testing.T) {
 	osUser := "ec2-user"
 	genKey := true
 	input := StartInput{
+		MFAToken:   &mfa,
+		Region:     &region,
+		Profile:    &profile,
+		Target:     &target,
+		TargetType: &targetType,
+		PortNumber: &port,
+		PublicKey:  &pubKey,
+		OSUser:     &osUser,
+		GenKeyPair: &genKey,
+	}
+
+	gomock.InOrder(
+		m.EXPECT().NewWithConfig(gomock.Eq(&aws.Config{
+			Region:   *input.Region,
+			Profile:  *input.Profile,
+			MFAToken: *input.MFAToken,
+		})).Return(nil),
+		m.EXPECT().StartSSH(
+			gomock.Eq(*input.TargetType),
+			gomock.Eq(*input.Target),
+			gomock.Eq(*input.OSUser),
+			gomock.Eq(*input.PortNumber),
+			gomock.Any(),
+		).Return(nil),
+	)
+
+	assert.NoError(t, input.start(m))
+
+	// DNS
+	target = "test.local"
+	targetType = aws.TargetTypePrivateDNS
+	input = StartInput{
+		MFAToken:   &mfa,
+		Region:     &region,
+		Profile:    &profile,
+		Target:     &target,
+		TargetType: &targetType,
+		PortNumber: &port,
+		PublicKey:  &pubKey,
+		OSUser:     &osUser,
+		GenKeyPair: &genKey,
+	}
+
+	gomock.InOrder(
+		m.EXPECT().NewWithConfig(gomock.Eq(&aws.Config{
+			Region:   *input.Region,
+			Profile:  *input.Profile,
+			MFAToken: *input.MFAToken,
+		})).Return(nil),
+		m.EXPECT().StartSSH(
+			gomock.Eq(*input.TargetType),
+			gomock.Eq(*input.Target),
+			gomock.Eq(*input.OSUser),
+			gomock.Eq(*input.PortNumber),
+			gomock.Any(),
+		).Return(nil),
+	)
+
+	assert.NoError(t, input.start(m))
+
+	// Name
+	target = "Backend"
+	targetType = aws.TargetTypePrivateDNS
+	input = StartInput{
+		MFAToken:   &mfa,
+		Region:     &region,
+		Profile:    &profile,
+		Target:     &target,
+		TargetType: &targetType,
+		PortNumber: &port,
+		PublicKey:  &pubKey,
+		OSUser:     &osUser,
+		GenKeyPair: &genKey,
+	}
+
+	gomock.InOrder(
+		m.EXPECT().NewWithConfig(gomock.Eq(&aws.Config{
+			Region:   *input.Region,
+			Profile:  *input.Profile,
+			MFAToken: *input.MFAToken,
+		})).Return(nil),
+		m.EXPECT().StartSSH(
+			gomock.Eq(*input.TargetType),
+			gomock.Eq(*input.Target),
+			gomock.Eq(*input.OSUser),
+			gomock.Eq(*input.PortNumber),
+			gomock.Any(),
+		).Return(nil),
+	)
+
+	assert.NoError(t, input.start(m))
+
+	// Deprecated Name
+	targetType = aws.DeprecatedTargetTypeName
+	input = StartInput{
 		MFAToken:   &mfa,
 		Region:     &region,
 		Profile:    &profile,


### PR DESCRIPTION
Rolling back removal of `name-tag` session and ssh target type. Addressing issue #117 