### PR TITLE
aws: adding tracing, max retries for AWS api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fix
 - **bazel:** docker rules
+- **pre-commit:** adding Gazelle run during fmt phase
 
 
 <a name="0.5.3"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Aws
+- customizing default retryer for AWS api calls
+
 ### Chore
 - **deps:** bumping Go and tidying dependecies
 - **deps:** update module aws/aws-sdk-go to v1.34.2

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -81,6 +81,7 @@ Filter format examples:
 			listType := cfg.GetString("list-type")
 			instanceIDs := cfg.GetStringSlice("filters.instance.ids")
 			mfaToken := cfg.GetString("mfa")
+			trace := log.IsLevelEnabled(log.TraceLevel)
 			// hack to get map[string]string from args
 			// https://github.com/spf13/viper/issues/608
 			if cmd.Flags().Changed("session-filters") {
@@ -113,6 +114,7 @@ Filter format examples:
 				"instanceIDs":    instanceIDs,
 				"sessionFilters": sessionFilters,
 				"tags":           tags,
+				"trace":          trace,
 			}).Debug("List inputs")
 			input := &list.StartInput{
 				OutputFormat: &outputFormat,
@@ -122,6 +124,7 @@ Filter format examples:
 				Filters:      &filters,
 				Interactive:  &interactive,
 				Type:         &listType,
+				Trace:        &trace,
 			}
 			err := list.Start(input)
 			if err != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -36,12 +36,14 @@ var sessionCmd = &cobra.Command{
 		profile := cfg.GetString("profile")
 		region := cfg.GetString("region")
 		mfaToken := cfg.GetString("mfa")
+		trace := log.IsLevelEnabled(log.TraceLevel)
 		log.WithFields(log.Fields{
 			"target":  target,
 			"type":    targetType,
 			"region":  region,
 			"profile": profile,
 			"mfa":     mfaToken,
+			"trace":   trace,
 		}).Debug("Session inputs")
 		input := &session.StartInput{
 			Target:     &target,
@@ -49,6 +51,7 @@ var sessionCmd = &cobra.Command{
 			Region:     &region,
 			Profile:    &profile,
 			MFAToken:   &mfaToken,
+			Trace:      &trace,
 		}
 		// returns err
 		return session.Start(input)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -52,6 +52,7 @@ var (
 			genKeyPair := cfg.GetBool("gen-key-pair")
 			genKeyDir := cfg.GetString("gen-key-dir")
 			mfaToken := cfg.GetString("mfa")
+			trace := log.IsLevelEnabled(log.TraceLevel)
 			if genKeyPair {
 				stat, err := os.Stat(genKeyDir)
 				if !(err == nil && stat.IsDir()) {
@@ -79,6 +80,7 @@ var (
 				"os-user":      OSUser,
 				"gen-key-pair": genKeyPair,
 				"gen-key-dir":  genKeyDir,
+				"trace":        trace,
 			}).Debug("ssh inputs")
 			input := &ssh.StartInput{
 				Target:     &target,
@@ -90,6 +92,7 @@ var (
 				Region:     &region,
 				Profile:    &profile,
 				MFAToken:   &mfaToken,
+				Trace:      &trace,
 			}
 			// returns err
 			return ssh.Start(input)

--- a/pkg/aws/BUILD.bazel
+++ b/pkg/aws/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
     importpath = "github.com/danmx/sigil/pkg/aws",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/aws/log:go_default_library",
         "//pkg/os:go_default_library",
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/client:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/credentials/stscreds:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_aws_aws_sdk_go//service/ec2:go_default_library",

--- a/pkg/aws/log/BUILD.bazel
+++ b/pkg/aws/log/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["log.go"],
+    importpath = "github.com/danmx/sigil/pkg/aws/log",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_aws_aws_sdk_go//aws:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)

--- a/pkg/aws/log/log.go
+++ b/pkg/aws/log/log.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	log "github.com/sirupsen/logrus"
+)
+
+// A traceLogger provides a minimalistic logger satisfying the aws.Logger interface.
+type traceLogger struct{}
+
+// newTraceLogger returns a Logger which will write log messages to current logger
+func NewTraceLogger() aws.Logger {
+	return &traceLogger{}
+}
+
+// Log logs the parameters to the stdlib logger. See log.Println.
+func (l traceLogger) Log(args ...interface{}) {
+	log.Trace(args) //nolint:govet // AWS Logger to Logrus
+}

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -46,6 +46,7 @@ type StartInput struct {
 	Region       *string
 	Profile      *string
 	Filters      *aws.Filters
+	Trace        *bool
 }
 
 // Start will output a ist of all available EC2 instances
@@ -56,6 +57,7 @@ func Start(input *StartInput) error {
 		Region:   *input.Region,
 		Profile:  *input.Profile,
 		MFAToken: *input.MFAToken,
+		Trace:    *input.Trace,
 	})
 	if err != nil {
 		log.Error(err)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -18,6 +18,7 @@ type StartInput struct {
 	MFAToken   *string
 	Region     *string
 	Profile    *string
+	Trace      *bool
 }
 
 // Start will start a session in chosen instance
@@ -30,6 +31,7 @@ func (input *StartInput) start(provider aws.CloudInstances) error {
 		Region:   *input.Region,
 		Profile:  *input.Profile,
 		MFAToken: *input.MFAToken,
+		Trace:    *input.Trace,
 	})
 	if err != nil {
 		log.Error("Failed to generate new provider")

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -21,10 +21,12 @@ func TestStart(t *testing.T) {
 	mfa := "123456"
 	region := "eu-west-1"
 	profile := "west"
+	trace := false
 	input := StartInput{
 		MFAToken: &mfa,
 		Region:   &region,
 		Profile:  &profile,
+		Trace:    &trace,
 	}
 	// Instance ID
 	target := "i-xxxxxxxxxxxxxxxx1"
@@ -36,6 +38,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
 	)
@@ -48,6 +51,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
 	)
@@ -60,6 +64,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
 	)
@@ -71,6 +76,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSession(gomock.Eq(*input.TargetType), gomock.Eq(*input.Target)).Return(nil),
 	)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -31,6 +31,7 @@ type StartInput struct {
 	MFAToken   *string
 	Region     *string
 	Profile    *string
+	Trace      *bool
 }
 
 // Start will start ssh session
@@ -43,6 +44,7 @@ func (input *StartInput) start(provider aws.CloudSSH) error {
 		Region:   *input.Region,
 		Profile:  *input.Profile,
 		MFAToken: *input.MFAToken,
+		Trace:    *input.Trace,
 	})
 	if err != nil {
 		log.Error(err)

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -30,6 +30,7 @@ func TestStart(t *testing.T) {
 	pubKey := path.Join(os.TempDir(), "sigil_test.pub")
 	osUser := "ec2-user"
 	genKey := true
+	trace := false
 	input := StartInput{
 		MFAToken:   &mfa,
 		Region:     &region,
@@ -40,6 +41,7 @@ func TestStart(t *testing.T) {
 		PublicKey:  &pubKey,
 		OSUser:     &osUser,
 		GenKeyPair: &genKey,
+		Trace:      &trace,
 	}
 
 	gomock.InOrder(
@@ -47,6 +49,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSSH(
 			gomock.Eq(*input.TargetType),
@@ -72,6 +75,7 @@ func TestStart(t *testing.T) {
 		PublicKey:  &pubKey,
 		OSUser:     &osUser,
 		GenKeyPair: &genKey,
+		Trace:      &trace,
 	}
 
 	gomock.InOrder(
@@ -79,6 +83,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSSH(
 			gomock.Eq(*input.TargetType),
@@ -104,6 +109,7 @@ func TestStart(t *testing.T) {
 		PublicKey:  &pubKey,
 		OSUser:     &osUser,
 		GenKeyPair: &genKey,
+		Trace:      &trace,
 	}
 
 	gomock.InOrder(
@@ -111,6 +117,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSSH(
 			gomock.Eq(*input.TargetType),
@@ -135,6 +142,7 @@ func TestStart(t *testing.T) {
 		PublicKey:  &pubKey,
 		OSUser:     &osUser,
 		GenKeyPair: &genKey,
+		Trace:      &trace,
 	}
 
 	gomock.InOrder(
@@ -142,6 +150,7 @@ func TestStart(t *testing.T) {
 			Region:   *input.Region,
 			Profile:  *input.Profile,
 			MFAToken: *input.MFAToken,
+			Trace:    *input.Trace,
 		})).Return(nil),
 		m.EXPECT().StartSSH(
 			gomock.Eq(*input.TargetType),

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -7,7 +7,7 @@ test(){
 }
 
 fmt() {
-    bazelisk run :gofmt
+    bazelisk run :gazelle && bazelisk run :gofmt
 }
 
 lint() {


### PR DESCRIPTION
Addressing #132 by:
- setting max retries of AWS API calls to 10,
- setting min retry delay to 1 sec and when throttled to 2 sec,
- adding tracing of AWS API calls when `log-level` is set to `trace`.