### PR TITLE
fix(aws): reducing timeouts to speed up error feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+<a name="0.6.1"></a>
+## [0.6.1] - 2020-08-19
+### Chore
+- **release:** version 0.6.1
+
 ### Fix
 - **aws:** reducing timeouts to speed up error feedback loop
 
@@ -207,7 +213,8 @@
 <a name="0.0.1"></a>
 ## 0.0.1 - 2019-03-18
 
-[Unreleased]: https://github.com/danmx/sigil/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/danmx/sigil/compare/0.6.1...HEAD
+[0.6.1]: https://github.com/danmx/sigil/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/danmx/sigil/compare/0.5.3...0.6.0
 [0.5.3]: https://github.com/danmx/sigil/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/danmx/sigil/compare/0.5.1...0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Fix
+- **aws:** reducing timeouts to speed up error feedback loop
+
 
 <a name="0.6.0"></a>
 ## [0.6.0] - 2020-08-16

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -88,11 +88,11 @@ const (
 	maxResults int64 = 50
 	pluginName       = "session-manager-plugin"
 	// API calls retry configuration
-	numMaxRetries    = 10
-	minRetryDelay    = 1 * time.Second
-	minThrottleDelay = 2 * time.Second
-	maxRetryDelay    = client.DefaultRetryerMaxRetryDelay
-	maxThrottleDelay = client.DefaultRetryerMaxThrottleDelay
+	numMaxRetries    = 5
+	minRetryDelay    = 10 * time.Millisecond
+	minThrottleDelay = 500 * time.Millisecond
+	maxRetryDelay    = 1 * time.Second
+	maxThrottleDelay = 4 * time.Second
 	// TargetTypeInstanceID points to an instance ID type
 	TargetTypeInstanceID = "instance-id"
 	// TargetTypePrivateDNS points to a private DNS type

--- a/tools/get_workspace_status.sh
+++ b/tools/get_workspace_status.sh
@@ -3,7 +3,7 @@
 set -eu
 
 appName="sigil"
-appVersion="${VERSION:-0.6.0}"
+appVersion="${VERSION:-0.6.1}"
 gitCommit="${GIT_COMMIT:-$(git rev-parse HEAD)}"
 gitBranch="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 


### PR DESCRIPTION
I've noticed extremely slow error feedback loop e.g. for broken credentials. I decided to keep a feedback loop significantly faster for non-throttled errors.

Benchmarked with an expired token errors (non-throttled):

```console
$ hyperfine -i 'bazel-out/darwin-fastbuild-ST-cff33a8e9d06/bin/dev/sigil --region eu-central-1 --log-level fatal ls'
Benchmark #1: bazel-out/darwin-fastbuild-ST-cff33a8e9d06/bin/dev/sigil --region eu-central-1 --log-level fatal ls
  Time (mean ± σ):      1.621 s ±  2.044 s    [User: 13.7 ms, System: 41.3 ms]
  Range (min … max):    0.852 s …  7.436 s    10 runs
```

For throttled environments it should still capable to work without errors (CC: @klauern) even though times and number of retries are reduced.