### PR TITLE
Target deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+<a name="0.7.0"></a>
+## [0.7.0] - 2020-08-27
+### Chore
+- **release:** version 0.7.0
+
 ### Feat
 - **cmd:** moving target to arg instead of separate flag
 
@@ -220,7 +226,8 @@
 <a name="0.0.1"></a>
 ## 0.0.1 - 2019-03-18
 
-[Unreleased]: https://github.com/danmx/sigil/compare/0.6.1...HEAD
+[Unreleased]: https://github.com/danmx/sigil/compare/0.7.0...HEAD
+[0.7.0]: https://github.com/danmx/sigil/compare/0.6.1...0.7.0
 [0.6.1]: https://github.com/danmx/sigil/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/danmx/sigil/compare/0.5.3...0.6.0
 [0.5.3]: https://github.com/danmx/sigil/compare/0.5.2...0.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Feat
+- **cmd:** moving target to arg instead of separate flag
+
 ### Fix
 - **aws:** error log on a send ssh pub key failure
 - **docs:** adding profile config entry description

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ docker run --rm -it -v "${HOME}"/.sigil:/home/nonroot/.sigil -v "${HOME}"/.aws:/
 Binary:
 
 ```shell
-sigil -r eu-west-1 session --type instance-id --target i-xxxxxxxxxxxxxxxxx
+sigil -r eu-west-1 session --type instance-id i-xxxxxxxxxxxxxxxxx
 ```
 
 Using with [aws-vault](https://github.com/99designs/aws-vault):
 
 ```shell
-aws-vault exec AWS_PROFILE -- sigil -r eu-west-1 session --type instance-id --target i-xxxxxxxxxxxxxxxxx
+aws-vault exec AWS_PROFILE -- sigil -r eu-west-1 session --type instance-id i-xxxxxxxxxxxxxxxxx
 ```
 
 ### SSH integration
@@ -86,11 +86,11 @@ Add an entry to your `ssh_config`:
 Host i-* mi-*
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
+    ProxyCommand sigil ssh --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/ %h
 Host *.compute.internal
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --type private-dns --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
+    ProxyCommand sigil ssh --type private-dns --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/ %h
 ```
 
 and run:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ brew install danmx/sigil/sigil
 ### Docker
 
 ```shell
-docker pull danmx/sigil:0.6
+docker pull danmx/sigil:0.7
 ```
 
 ## Examples
@@ -63,7 +63,7 @@ docker pull danmx/sigil:0.6
 Docker:
 
 ```shell
-docker run --rm -it -v "${HOME}"/.sigil:/home/nonroot/.sigil -v "${HOME}"/.aws:/home/.aws danmx/sigil:0.6 list --output-format wide
+docker run --rm -it -v "${HOME}"/.sigil:/home/nonroot/.sigil -v "${HOME}"/.aws:/home/.aws danmx/sigil:0.7 list --output-format wide
 ```
 
 Binary:

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,8 +20,9 @@ var (
 	}
 	// listCmd represents the list command
 	listCmd = &cobra.Command{
-		Use:   "list",
-		Short: "List available EC2 instances or SSM sessions",
+		Use:                   "list [--type TYPE] ... { [--instance-ids IDs] [--instance-tags TAGS] | [--session-filters FILTERS] }",
+		DisableFlagsInUseLine: true,
+		Short:                 "List available EC2 instances or SSM sessions",
 		Long: `Show list of all EC2 instances with AWS SSM Agent running or active SSM sessions.
 
 Supported groups of filters:

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -12,12 +12,17 @@ import (
 
 // sessionCmd represents the session command
 var sessionCmd = &cobra.Command{
-	Use:     "session",
-	Short:   "Start a session",
-	Long:    `Start a new session in chosen EC2 instance.`,
-	Aliases: []string{"sess", "s"},
-	Example: fmt.Sprintf("%s session --type instance-id --target i-xxxxxxxxxxxxxxxxx", appName),
+	Use:                   "session [--type TYPE] ... TARGET",
+	DisableFlagsInUseLine: true,
+	Short:                 "Start a session",
+	Long:                  `Start a new session in chosen EC2 instance.`,
+	Aliases:               []string{"sess", "s"},
+	Example:               fmt.Sprintf("%s session --type instance-id i-xxxxxxxxxxxxxxxxx", appName),
+	Args:                  cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 && cmd.Flags().Lookup("target").Changed {
+			return fmt.Errorf("can't use both target argument (%s) and deprecated flag (%s)", args[0], cmd.Flags().Lookup("target").Value.String())
+		}
 		// Config bindings
 		for _, flag := range []string{"target", "type"} {
 			if err := cfg.BindPFlag(flag, cmd.Flags().Lookup(flag)); err != nil {
@@ -26,6 +31,9 @@ var sessionCmd = &cobra.Command{
 				}).Error(err)
 				return err
 			}
+		}
+		if len(args) > 0 {
+			cfg.Set("target", args[0])
 		}
 		// returns err
 		return aws.VerifyDependencies()
@@ -63,5 +71,10 @@ func init() {
 	rootCmd.AddCommand(sessionCmd)
 
 	sessionCmd.Flags().String("target", "", "specify the target depending on the type")
+	// Deprecating the target flag
+	err := sessionCmd.Flags().MarkDeprecated("target", "this flag will be deprecated in future releases, use args instead")
+	if err != nil {
+		log.WithField("flag", sessionCmd.Flags().Lookup("target")).Error(err)
+	}
 	sessionCmd.Flags().String("type", aws.TargetTypeInstanceID, fmt.Sprintf("specify target type: %s/%s/%s", aws.TargetTypeInstanceID, aws.TargetTypePrivateDNS, aws.TargetTypeName))
 }

--- a/docs/00-get-started.md
+++ b/docs/00-get-started.md
@@ -34,7 +34,7 @@ brew install danmx/sigil/sigil
 ### Docker
 
 ```shell
-docker pull danmx/sigil:0.6
+docker pull danmx/sigil:0.7
 ```
 
 ### Source code

--- a/docs/usage/00-list.md
+++ b/docs/usage/00-list.md
@@ -4,7 +4,7 @@ This command list all active instances and sessions that match the filter.
 When interactive mode is enabled you can start a session in a given instance or terminate active session.
 
 ```console
-sigil list [flags]
+sigil list [--type TYPE] ... { [--instance-ids IDs] [--instance-tags TAGS] | [--session-filters FILTERS] }
 ```
 
 [Man](../man/sigil_list.md) page

--- a/docs/usage/10-session.md
+++ b/docs/usage/10-session.md
@@ -3,7 +3,7 @@
 Start a new session in chosen EC2 instance based on its instance ID, name tag, or private DNS name.
 
 ```console
-sigil session [flags]
+sigil session [--type TYPE] ... TARGET
 ```
 
 [Man](../man/sigil_session.md) page
@@ -23,7 +23,7 @@ Config file settings that affect the command
 ## Examples
 
 ```console
-$ sigil -r eu-west-1 session --type instance-id --target i-xxxxxxxxxxxxxxxxx
+$ sigil -r eu-west-1 session --type instance-id i-xxxxxxxxxxxxxxxxx
 Starting session with SessionId: example
 sh-4.2$
 ```

--- a/docs/usage/20-ssh.md
+++ b/docs/usage/20-ssh.md
@@ -3,7 +3,7 @@
 Start a new ssh for chosen EC2 instance based on its instance ID, name tag, or private DNS name.
 
 ```console
-sigil ssh [flags]
+sigil ssh [--type TYPE] ... { [--gen-key-pair] [--gen-key-dir DIR] | [--pub-key PUB_KEY_PATH] } TARGET
 ```
 
 [Man](../man/sigil_ssh.md) page
@@ -31,11 +31,11 @@ Config file settings that affect the command
 Host i-* mi-*
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
+    ProxyCommand sigil ssh --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/ %h
 Host *.compute.internal
     IdentityFile /tmp/sigil/%h/temp_key
     IdentitiesOnly yes
-    ProxyCommand sigil ssh --type private-dns --target %h --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/
+    ProxyCommand sigil ssh --type private-dns --port %p --pub-key /tmp/sigil/%h/temp_key.pub --gen-key-pair --os-user %r --gen-key-dir /tmp/sigil/%h/ %h
 ```
 
 ```console

--- a/tools/get_workspace_status.sh
+++ b/tools/get_workspace_status.sh
@@ -3,7 +3,7 @@
 set -eu
 
 appName="sigil"
-appVersion="${VERSION:-0.6.1}"
+appVersion="${VERSION:-0.7.0}"
 gitCommit="${GIT_COMMIT:-$(git rev-parse HEAD)}"
 gitBranch="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 


### PR DESCRIPTION
- Deprecating `target` flag from `ssh` and `session` commands.
- Expanding commands usage information